### PR TITLE
Added the ability to hide the attachments button in the chat screen

### DIFF
--- a/sample-with-framework/Applozic/Applozic/ALChannelMsgCell.h
+++ b/sample-with-framework/Applozic/Applozic/ALChannelMsgCell.h
@@ -6,8 +6,6 @@
 //  Copyright © 2017 applozic Inc. All rights reserved.
 //
 
-#define CH_MESSAGE_TEXT_SIZE 14
-
 #import <Applozic/Applozic.h>
 
 @interface ALChannelMsgCell : ALChatCell

--- a/sample-with-framework/Applozic/Applozic/ALChannelMsgCell.m
+++ b/sample-with-framework/Applozic/Applozic/ALChannelMsgCell.m
@@ -20,7 +20,7 @@
 {
     [super populateCell:alMessage viewSize:viewSize];
     
-    [self.mMessageLabel setFont:[UIFont fontWithName:@"Helvetica" size:CH_MESSAGE_TEXT_SIZE]];
+    [self.mMessageLabel setFont:[UIFont fontWithName:@"Helvetica" size:[ALApplozicSettings getFontSizeForMessages]]];
     
     [self.mMessageLabel setTextAlignment:NSTextAlignmentCenter];
     [self.mMessageLabel setText:alMessage.message];

--- a/sample-with-framework/Applozic/Applozic/ALMediaBaseCell.h
+++ b/sample-with-framework/Applozic/Applozic/ALMediaBaseCell.h
@@ -11,7 +11,6 @@
  ***************************************************************************************/
 
 #define DATE_LABEL_SIZE 12
-#define MESSAGE_TEXT_SIZE 14
 
 #define USER_PROFILE_PADDING_X 5
 #define USER_PROFILE_PADDING_X_OUTBOX 50

--- a/sample-with-framework/Applozic/Applozic/ALMediaBaseCell.m
+++ b/sample-with-framework/Applozic/Applozic/ALMediaBaseCell.m
@@ -82,7 +82,7 @@
         [self.contentView addSubview:self.mDowloadRetryButton];
 
         self.imageWithText = [[UITextView alloc] init];
-        [self.imageWithText setFont:[UIFont fontWithName:[ALApplozicSettings getFontFace] size:MESSAGE_TEXT_SIZE]];
+        [self.imageWithText setFont:[UIFont fontWithName:[ALApplozicSettings getFontFace] size:[ALApplozicSettings getFontSizeForMessages]]];
         self.imageWithText.editable = NO;
         self.imageWithText.scrollEnabled = NO;
         self.imageWithText.textContainerInset = UIEdgeInsetsZero;

--- a/sample-with-framework/Applozic/Applozic/ALUIConstant.m
+++ b/sample-with-framework/Applozic/Applozic/ALUIConstant.m
@@ -114,7 +114,7 @@
     CGSize theTextSize = [ALUtilityClass getSizeForText:alMessage.message
                                                maxWidth:cellFrame.size.width - 115
                                                    font:@"Helvetica"
-                                               fontSize:CH_MESSAGE_TEXT_SIZE];
+                                               fontSize:[ALApplozicSettings getFontSizeForMessages]];
     
     CGFloat HEIGHT = theTextSize.height + 30;
     

--- a/sample-with-framework/Applozic/Applozic/Handlers/ALApplozicSettings.h
+++ b/sample-with-framework/Applozic/Applozic/Handlers/ALApplozicSettings.h
@@ -12,6 +12,7 @@
 #define NAVIGATION_BAR_COLOUR @"com.applozic.userdefault.NAVIGATION_BAR_COLOUR"
 #define NAVIGATION_BAR_ITEM_COLOUR @"com.applozic.userdefault.NAVIGATION_BAR_ITEM_COLOUR"
 #define REFRESH_BUTTON_VISIBILITY @"com.applozic.userdefault.REFRESH_BUTTON_VISIBILITY"
+#define ATTACHMENT_BUTTON_VISIBILITY @"com.applozic.userdefault.ATTACHMENT_BUTTON_VISIBILITY"
 #define CONVERSATION_TITLE @"com.applozic.userdefault.CONVERSATION_TITLE"
 #define BACK_BUTTON_TITLE @"com.applozic.userdefault.BACK_BUTTON_TITLE"
 #define FONT_FACE @"com.applozic.userdefault.FONT_FACE"
@@ -108,6 +109,10 @@
 +(void)hideRefreshButton:(BOOL)state;
 
 +(BOOL)isRefreshButtonHidden;
+
++(void)hideAttachmentButton:(BOOL)state;
+
++(BOOL)isAttachmentButtonHidden;
 
 +(void)setTitleForConversationScreen:(NSString *)titleText;
 

--- a/sample-with-framework/Applozic/Applozic/Handlers/ALApplozicSettings.h
+++ b/sample-with-framework/Applozic/Applozic/Handlers/ALApplozicSettings.h
@@ -9,6 +9,7 @@
 #define USER_PROFILE_PROPERTY @"com.applozic.userdefault.USER_PROFILE_PROPERTY"
 #define SEND_MSG_COLOUR @"com.applozic.userdefault.SEND_MSG_COLOUR"
 #define RECEIVE_MSG_COLOUR @"com.applozic.userdefault.RECEIVE_MSG_COLOUR"
+#define MESSAGE_TEXT_SIZE @"com.applozic.userdefault.MESSAGE_TEXT_SIZE"
 #define NAVIGATION_BAR_COLOUR @"com.applozic.userdefault.NAVIGATION_BAR_COLOUR"
 #define NAVIGATION_BAR_ITEM_COLOUR @"com.applozic.userdefault.NAVIGATION_BAR_ITEM_COLOUR"
 #define REFRESH_BUTTON_VISIBILITY @"com.applozic.userdefault.REFRESH_BUTTON_VISIBILITY"
@@ -97,6 +98,10 @@
 +(UIColor *)getSendMsgColor;
 
 +(UIColor *)getReceiveMsgColor;
+
++(void)setFontSizeForMessages:(CGFloat)fontSize;
+
++(CGFloat)getFontSizeForMessages;
 
 +(void)setColorForNavigation:(UIColor *)barColor;
 

--- a/sample-with-framework/Applozic/Applozic/Handlers/ALApplozicSettings.m
+++ b/sample-with-framework/Applozic/Applozic/Handlers/ALApplozicSettings.m
@@ -86,6 +86,17 @@
     return [UIColor whiteColor];
 }
 
++(void)setFontSizeForMessages:(CGFloat)fontSize
+{
+	[[NSUserDefaults standardUserDefaults] setFloat:fontSize forKey:MESSAGE_TEXT_SIZE];
+	[[NSUserDefaults standardUserDefaults] synchronize];
+}
+
++(CGFloat)getFontSizeForMessages
+{
+	return [[NSUserDefaults standardUserDefaults] floatForKey:MESSAGE_TEXT_SIZE];
+}
+
 +(void)setColorForNavigation:(UIColor *)barColor
 {
     NSData *barColorData = [NSKeyedArchiver archivedDataWithRootObject:barColor];

--- a/sample-with-framework/Applozic/Applozic/Handlers/ALApplozicSettings.m
+++ b/sample-with-framework/Applozic/Applozic/Handlers/ALApplozicSettings.m
@@ -127,6 +127,17 @@
     return [[NSUserDefaults standardUserDefaults] boolForKey:REFRESH_BUTTON_VISIBILITY];
 }
 
++(void)hideAttachmentButton:(BOOL)state
+{
+	[[NSUserDefaults standardUserDefaults] setBool:state forKey:ATTACHMENT_BUTTON_VISIBILITY];
+	[[NSUserDefaults standardUserDefaults] synchronize];
+}
+
++(BOOL)isAttachmentButtonHidden
+{
+	return [[NSUserDefaults standardUserDefaults] boolForKey:ATTACHMENT_BUTTON_VISIBILITY];
+}
+
 +(void)setTitleForBackButtonMsgVC:(NSString *)backButtonTitle
 {
     [[NSUserDefaults standardUserDefaults] setValue:backButtonTitle forKey:BACK_BUTTON_TITLE];

--- a/sample-with-framework/Applozic/Applozic/ViewControllers/ALBaseViewController.m
+++ b/sample-with-framework/Applozic/Applozic/ViewControllers/ALBaseViewController.m
@@ -135,6 +135,20 @@ static CGFloat const sendTextViewCornerRadius = 15.0f;
         [self.navRightBarButtonItems addObject:refreshButton];
     }
 
+	self.attachmentOutlet.hidden = [ALApplozicSettings isAttachmentButtonHidden];
+	if ([ALApplozicSettings isAttachmentButtonHidden])
+	{
+		// The attachment button has been hidden, now change it's width to zero
+		// so that the message input field takes up the newly available space
+		[NSLayoutConstraint constraintWithItem:self.attachmentOutlet
+									 attribute:NSLayoutAttributeWidth
+									 relatedBy:NSLayoutRelationEqual
+										toItem:NULL
+									 attribute:NSLayoutAttributeWidth
+									multiplier:1
+									  constant:0].active = YES;
+	}
+
     self.navigationItem.rightBarButtonItems = [self.navRightBarButtonItems mutableCopy];
     
     self.label = [[UILabel alloc] init];

--- a/sample-with-framework/Applozic/Applozic/ViewControllers/ALContactMessageCell.m
+++ b/sample-with-framework/Applozic/Applozic/ViewControllers/ALContactMessageCell.m
@@ -11,7 +11,6 @@
 #define MT_OUTBOX_CONSTANT "5"
 
 #define DATE_LABEL_SIZE 12
-#define MESSAGE_TEXT_SIZE 14
 
 #import "ALContactMessageCell.h"
 #import "ALUtilityClass.h"

--- a/sample-with-framework/Applozic/Applozic/Views/ALChatCell.m
+++ b/sample-with-framework/Applozic/Applozic/Views/ALChatCell.m
@@ -5,7 +5,6 @@
 //  Copyright (c) 2015 AppLozic. All rights reserved.
 //
 
-#define MESSAGE_TEXT_SIZE 14
 #define DATE_LABEL_SIZE 12
 
 #import "ALChatCell.h"
@@ -98,7 +97,7 @@
             fontName = DEFAULT_FONT_NAME;
         }
         
-        self.mMessageLabel.font = [UIFont fontWithName:[ALApplozicSettings getFontFace] size:MESSAGE_TEXT_SIZE];
+        self.mMessageLabel.font = [UIFont fontWithName:[ALApplozicSettings getFontFace] size:[ALApplozicSettings getFontSizeForMessages]];
         self.mMessageLabel.textColor = [UIColor grayColor];
         [self.contentView addSubview:self.mMessageLabel];
         
@@ -357,7 +356,7 @@
     
     /*    ====================================== END =================================  */
     
-    self.mMessageLabel.font = [UIFont fontWithName:[ALApplozicSettings getFontFace] size:MESSAGE_TEXT_SIZE];
+    self.mMessageLabel.font = [UIFont fontWithName:[ALApplozicSettings getFontFace] size:[ALApplozicSettings getFontSizeForMessages]];
     if(alMessage.contentType == ALMESSAGE_CONTENT_TEXT_HTML)
     {
         

--- a/sample-with-framework/Applozic/Applozic/Views/ALImageCell.m
+++ b/sample-with-framework/Applozic/Applozic/Views/ALImageCell.m
@@ -7,7 +7,6 @@
 //
 
 #define DATE_LABEL_SIZE 12
-#define MESSAGE_TEXT_SIZE 14
 
 #import "ALImageCell.h"
 #import "UIImageView+WebCache.h"

--- a/sample-with-framework/applozicdemo/ALChatManager.m
+++ b/sample-with-framework/applozicdemo/ALChatManager.m
@@ -365,6 +365,7 @@
     [ALApplozicSettings setColorForNavigation:[UIColor colorWithRed:66.0/255 green:173.0/255 blue:247.0/255 alpha:1]];
     [ALApplozicSettings setColorForNavigationItem:[UIColor whiteColor]];
     [ALApplozicSettings hideRefreshButton:NO];
+	[ALApplozicSettings hideAttachmentButton:NO];                         /* SET VISIBLITY FOR ATTACHMENT BUTTON (USED IN THE CHAT VC) */
     [ALUserDefaultsHandler setNavigationRightButtonHidden:NO];
     [ALUserDefaultsHandler setBottomTabBarHidden:NO];
     [ALApplozicSettings setTitleForConversationScreen:@"Chats"];


### PR DESCRIPTION
Added a new configuration option to `ALApplozicSettings` that works the same way as all the other boolean options.

When the button is hidden, the chat message input field will take up the newly available space.