### PR TITLE
Feature: #385 - make setTitle on ALChatViewController public

### DIFF
--- a/sample-with-framework/Applozic/Applozic/ViewControllers/ALChatViewController.h
+++ b/sample-with-framework/Applozic/Applozic/ViewControllers/ALChatViewController.h
@@ -59,6 +59,7 @@
 -(void)individualNotificationhandler:(NSNotification *) notification;
 
 -(void)updateDeliveryStatus:(NSNotification *) notification;
+-(void) setTitle;
 
 //-(void) syncCall:(NSString *) contactId updateUI:(NSNumber *) updateUI alertValue: (NSString *) alertValue;
 -(void) syncCall:(ALMessage *) alMessage andMessageList:(NSMutableArray*)messageArray;


### PR DESCRIPTION
Make setTitle on ALChatViewController a public method so the navigation bar can be subclassed and modified.

Note: Call super on setTitle first, then customise the nav bar with additional objects etc.