### PR TITLE
Bug: fix issue #28 relating to checking if contact exists

### DIFF
--- a/sample-with-framework/Applozic/Applozic/ALContactService.m
+++ b/sample-with-framework/Applozic/Applozic/ALContactService.m
@@ -71,7 +71,7 @@
 -(BOOL) isContactExist:(NSString *) value{
    
     DB_CONTACT* contact= [alContactDBService getContactByKey:@"userId" value:value];
-    return !(contact.lastSeenAt==nil);
+    return !(contact == nil);
     
 }
 #pragma update OR insert contact


### PR DESCRIPTION
Updated method to check the actual contact variable if nil, instead of the lastseen status inside the variable. 

So check if the contact record actually exists.

Reference issue #395 . 
Incorrectly referenced issue 28 on Chat-ios-sdk library.