### PR TITLE
Bug: Issue #397 Updating of profile image's without changing URL

### DIFF
--- a/sample-with-framework/Applozic/Applozic/ALAudioCell.m
+++ b/sample-with-framework/Applozic/Applozic/ALAudioCell.m
@@ -166,11 +166,11 @@
         if(alContact.contactImageUrl)
         {
             NSURL * theUrl1 = [NSURL URLWithString:alContact.contactImageUrl];
-            [self.mUserProfileImageView sd_setImageWithURL:theUrl1];
+            [self.mUserProfileImageView sd_setImageWithURL:theUrl1 placeholderImage:nil options:SDWebImageRefreshCached];
         }
         else
         {
-            [self.mUserProfileImageView sd_setImageWithURL:[NSURL URLWithString:@""]];
+            [self.mUserProfileImageView sd_setImageWithURL:[NSURL URLWithString:@""] placeholderImage:nil options:SDWebImageRefreshCached];
             [self.mNameLabel setHidden:NO];
             self.mUserProfileImageView.backgroundColor = [ALColorUtility getColorForAlphabet:alMessage.to];
         }

--- a/sample-with-framework/Applozic/Applozic/ALDocumentsCell.m
+++ b/sample-with-framework/Applozic/Applozic/ALDocumentsCell.m
@@ -218,11 +218,11 @@
         if(alContact.contactImageUrl)
         {
             NSURL * theUrl1 = [NSURL URLWithString:alContact.contactImageUrl];
-            [self.mUserProfileImageView sd_setImageWithURL:theUrl1];
+            [self.mUserProfileImageView sd_setImageWithURL:theUrl1 placeholderImage:nil options:SDWebImageRefreshCached];
         }
         else
         {
-            [self.mUserProfileImageView sd_setImageWithURL:[NSURL URLWithString:@""]];
+            [self.mUserProfileImageView sd_setImageWithURL:[NSURL URLWithString:@""] placeholderImage:nil options:SDWebImageRefreshCached];
             [self.mNameLabel setHidden:NO];
             self.mUserProfileImageView.backgroundColor = [ALColorUtility getColorForAlphabet:receiverName];
         }

--- a/sample-with-framework/Applozic/Applozic/ALLocationCell.m
+++ b/sample-with-framework/Applozic/Applozic/ALLocationCell.m
@@ -141,11 +141,11 @@
         if(alContact.contactImageUrl)
         {
             NSURL * URL = [NSURL URLWithString:alContact.contactImageUrl];
-            [self.mUserProfileImageView sd_setImageWithURL:URL];
+            [self.mUserProfileImageView sd_setImageWithURL:URL placeholderImage:nil options:SDWebImageRefreshCached];
         }
         else
         {
-            [self.mUserProfileImageView sd_setImageWithURL:[NSURL URLWithString:@""]];
+            [self.mUserProfileImageView sd_setImageWithURL:[NSURL URLWithString:@""] placeholderImage:nil options:SDWebImageRefreshCached];
             [self.mNameLabel setHidden:NO];
             self.mUserProfileImageView.backgroundColor = [ALColorUtility getColorForAlphabet:receiverName];
         }

--- a/sample-with-framework/Applozic/Applozic/ALVideoCell.m
+++ b/sample-with-framework/Applozic/Applozic/ALVideoCell.m
@@ -190,11 +190,11 @@
         if(alContact.contactImageUrl)
         {
             NSURL * theUrl1 = [NSURL URLWithString:alContact.contactImageUrl];
-            [self.mUserProfileImageView sd_setImageWithURL:theUrl1];
+            [self.mUserProfileImageView sd_setImageWithURL:theUrl1 placeholderImage:nil options:SDWebImageRefreshCached];
         }
         else
         {
-            [self.mUserProfileImageView sd_setImageWithURL:[NSURL URLWithString:@""]];
+            [self.mUserProfileImageView sd_setImageWithURL:[NSURL URLWithString:@""] placeholderImage:nil options:SDWebImageRefreshCached];
             [self.mNameLabel setHidden:NO];
             self.mUserProfileImageView.backgroundColor = [ALColorUtility getColorForAlphabet:receiverName];
         }

--- a/sample-with-framework/Applozic/Applozic/Utilities/ALUtilityClass.m
+++ b/sample-with-framework/Applozic/Applozic/Utilities/ALUtilityClass.m
@@ -481,7 +481,7 @@
 +(void)setImageFromURL:(NSString *)urlString andImageView:(UIImageView *)imageView
 {
     NSURL * imageURL = [NSURL URLWithString:urlString];
-    [imageView sd_setImageWithURL:imageURL];
+    [imageView sd_setImageWithURL:imageURL placeholderImage:nil options:SDWebImageRefreshCached];
 }
 
 +(NSString *)stringFromTimeInterval:(NSTimeInterval)interval

--- a/sample-with-framework/Applozic/Applozic/ViewControllers/ALChatViewController.m
+++ b/sample-with-framework/Applozic/Applozic/ViewControllers/ALChatViewController.m
@@ -1556,7 +1556,7 @@
     // Image View ....
     UIImageView *imageView = [[UIImageView alloc] init];
     NSURL * url = [NSURL URLWithString:topicDetail.link];
-    [imageView sd_setImageWithURL:url];
+    [imageView sd_setImageWithURL:url placeholderImage:nil options:SDWebImageRefreshCached];
     
     imageView.frame = CGRectMake(5, 27, 50, 50);
     imageView.backgroundColor = [UIColor blackColor];

--- a/sample-with-framework/Applozic/Applozic/ViewControllers/ALContactMessageCell.m
+++ b/sample-with-framework/Applozic/Applozic/ViewControllers/ALContactMessageCell.m
@@ -200,11 +200,11 @@
         if(alContact.contactImageUrl)
         {
             NSURL * theUrl1 = [NSURL URLWithString:alContact.contactImageUrl];
-            [self.mUserProfileImageView sd_setImageWithURL:theUrl1];
+            [self.mUserProfileImageView sd_setImageWithURL:theUrl1 placeholderImage:nil options:SDWebImageRefreshCached];
         }
         else
         {
-            [self.mUserProfileImageView sd_setImageWithURL:[NSURL URLWithString:@""]];
+            [self.mUserProfileImageView sd_setImageWithURL:[NSURL URLWithString:@""] placeholderImage:nil options:SDWebImageRefreshCached];
             [self.mNameLabel setHidden:NO];
             self.mUserProfileImageView.backgroundColor = [ALColorUtility getColorForAlphabet:alMessage.to];
         }

--- a/sample-with-framework/Applozic/Applozic/ViewControllers/ALGroupCreationViewController.m
+++ b/sample-with-framework/Applozic/Applozic/ViewControllers/ALGroupCreationViewController.m
@@ -94,7 +94,7 @@
     NSURL *imageURL = [NSURL URLWithString:self.groupImageURL];
     if(imageURL.path.length)
     {
-        [self.groupIconView sd_setImageWithURL:imageURL];
+        [self.groupIconView sd_setImageWithURL:imageURL placeholderImage:nil options:SDWebImageRefreshCached];
     }
     else
     {

--- a/sample-with-framework/Applozic/Applozic/ViewControllers/ALGroupDetailViewController.m
+++ b/sample-with-framework/Applozic/Applozic/ViewControllers/ALGroupDetailViewController.m
@@ -725,7 +725,7 @@
     else if(alContact.contactImageUrl)
     {
         NSURL * theUrl = [NSURL URLWithString:alContact.contactImageUrl];
-        [self.memberIconImageView sd_setImageWithURL:theUrl];
+        [self.memberIconImageView sd_setImageWithURL:theUrl placeholderImage:nil options:SDWebImageRefreshCached];
     }
     else
     {
@@ -790,7 +790,7 @@
         NSURL * imageUrl = [NSURL URLWithString:self.alChannel.channelImageURL];
         if(imageUrl.path.length)
         {
-            [imageView sd_setImageWithURL:imageUrl];
+            [imageView sd_setImageWithURL:imageUrl placeholderImage:nil options:SDWebImageRefreshCached];
         }
         
         imageView.frame = CGRectMake((screenWidth/2)-30, 20, 60, 60);

--- a/sample-with-framework/Applozic/Applozic/ViewControllers/ALMessageInfoViewController.m
+++ b/sample-with-framework/Applozic/Applozic/ViewControllers/ALMessageInfoViewController.m
@@ -254,7 +254,7 @@
     ALContact *alContact = [alContactDBService loadContactByKey:@"userId" value:msgInfo.userId];
     
     NSURL * theUrl = [NSURL URLWithString:alContact.contactImageUrl];
-    [self.userImage sd_setImageWithURL:theUrl];
+    [self.userImage sd_setImageWithURL:theUrl placeholderImage:nil options:SDWebImageRefreshCached];
     [self.firstAlphabet setHidden:YES];
     [self.userName setText:[alContact getDisplayName]];
     

--- a/sample-with-framework/Applozic/Applozic/ViewControllers/ALMessagesViewController.m
+++ b/sample-with-framework/Applozic/Applozic/ViewControllers/ALMessagesViewController.m
@@ -716,14 +716,14 @@
             if(grpContact.contactImageUrl.length)
             {
                 NSURL * theUrl1 = [NSURL URLWithString:grpContact.contactImageUrl];
-                [contactCell.mUserImageView sd_setImageWithURL:theUrl1];
+                [contactCell.mUserImageView sd_setImageWithURL:theUrl1 placeholderImage:nil options:SDWebImageRefreshCached];
                 contactCell.imageNameLabel.hidden = YES;
                 nameIcon.hidden=YES;
             }
             else
             {
                 nameIcon.hidden = NO;
-                [contactCell.mUserImageView sd_setImageWithURL:[NSURL URLWithString:@""]];
+                [contactCell.mUserImageView sd_setImageWithURL:[NSURL URLWithString:@""] placeholderImage:nil options:SDWebImageRefreshCached];
                 contactCell.mUserImageView.backgroundColor = [ALColorUtility getColorForAlphabet:[grpContact getDisplayName]];
                 [nameIcon setText:[ALColorUtility getAlphabetForProfileImage:[grpContact getDisplayName]]];
             }
@@ -741,7 +741,7 @@
             NSURL * imageUrl = [NSURL URLWithString:alChannel.channelImageURL];
             if(imageUrl.path.length)
             {
-                [contactCell.mUserImageView sd_setImageWithURL:imageUrl];
+                [contactCell.mUserImageView sd_setImageWithURL:imageUrl placeholderImage:nil options:SDWebImageRefreshCached];
             }
             nameIcon.hidden = YES;
             contactCell.mUserNameLabel.text = [alChannel name];
@@ -756,14 +756,14 @@
         if(contact.contactImageUrl.length)
         {
             NSURL * theUrl1 = [NSURL URLWithString:contact.contactImageUrl];
-            [contactCell.mUserImageView sd_setImageWithURL:theUrl1];
+            [contactCell.mUserImageView sd_setImageWithURL:theUrl1 placeholderImage:nil options:SDWebImageRefreshCached];
             contactCell.imageNameLabel.hidden = YES;
             nameIcon.hidden= YES;
         }
         else
         {
             nameIcon.hidden = NO;
-            [contactCell.mUserImageView sd_setImageWithURL:[NSURL URLWithString:@""]];
+            [contactCell.mUserImageView sd_setImageWithURL:[NSURL URLWithString:@""] placeholderImage:nil options:SDWebImageRefreshCached];
             contactCell.mUserImageView.backgroundColor = [ALColorUtility getColorForAlphabet:[contact getDisplayName]];
             [nameIcon setText:[ALColorUtility getAlphabetForProfileImage:[contact getDisplayName]]];
         }
@@ -1099,13 +1099,13 @@
             NSURL * URL = [NSURL URLWithString:userDetail.imageLink];
             if(URL)
             {
-                [contactCell.mUserImageView sd_setImageWithURL:URL];
+                [contactCell.mUserImageView sd_setImageWithURL:URL placeholderImage:nil options:SDWebImageRefreshCached];
                 nameIcon.hidden = YES;
             }
             else
             {
                 nameIcon.hidden = NO;
-                [contactCell.mUserImageView sd_setImageWithURL:[NSURL URLWithString:@""]];
+                [contactCell.mUserImageView sd_setImageWithURL:[NSURL URLWithString:@""] placeholderImage:nil options:SDWebImageRefreshCached];
                 contactCell.mUserImageView.backgroundColor = [ALColorUtility getColorForAlphabet:[userDetail getDisplayName]];
             }
             [self.detailChatViewController setRefresh:YES];

--- a/sample-with-framework/Applozic/Applozic/ViewControllers/ALNewContactsViewController.m
+++ b/sample-with-framework/Applozic/Applozic/ViewControllers/ALNewContactsViewController.m
@@ -318,7 +318,7 @@
     ALNewContactCell *newContactCell = [self getCell:userDetail.userId];
     if(newContactCell && self.selectedSegment == 0)
     {
-        [newContactCell.contactPersonImageView sd_setImageWithURL:[NSURL URLWithString:userDetail.imageLink]];
+        [newContactCell.contactPersonImageView sd_setImageWithURL:[NSURL URLWithString:userDetail.imageLink] placeholderImage:nil options:SDWebImageRefreshCached];
         newContactCell.contactPersonName.text = [userDetail getDisplayName];
     }
 }
@@ -398,7 +398,7 @@
     UILabel* nameIcon = (UILabel*)[newContactCell viewWithTag:101];
     [nameIcon setTextColor:[UIColor whiteColor]];
     [nameIcon setHidden:YES];
-    [newContactCell.contactPersonImageView sd_setImageWithURL:[NSURL URLWithString:@""]];
+    [newContactCell.contactPersonImageView sd_setImageWithURL:[NSURL URLWithString:@""] placeholderImage:nil options:SDWebImageRefreshCached];
     newContactCell.contactPersonName.text = @"";
     [newContactCell.contactPersonImageView setHidden:NO];
     
@@ -424,7 +424,7 @@
                 {
                     if (contact.contactImageUrl)
                     {
-                        [newContactCell.contactPersonImageView sd_setImageWithURL:[NSURL URLWithString:contact.contactImageUrl]];
+                        [newContactCell.contactPersonImageView sd_setImageWithURL:[NSURL URLWithString:contact.contactImageUrl] placeholderImage:nil options:SDWebImageRefreshCached];
                     }
                     else
                     {
@@ -476,7 +476,7 @@
                     NSURL * imageUrl = [NSURL URLWithString:channel.channelImageURL];
                     if(imageUrl.path.length)
                     {
-                        [newContactCell.contactPersonImageView sd_setImageWithURL:imageUrl];
+                        [newContactCell.contactPersonImageView sd_setImageWithURL:imageUrl placeholderImage:nil options:SDWebImageRefreshCached];
                     }
                     [nameIcon setHidden:YES];
                 }

--- a/sample-with-framework/Applozic/Applozic/ViewControllers/ALReceiverUserProfileVC.m
+++ b/sample-with-framework/Applozic/Applozic/ViewControllers/ALReceiverUserProfileVC.m
@@ -57,7 +57,7 @@
     if(self.alContact.contactImageUrl)
     {
         NSURL * theUrl = [NSURL URLWithString:self.alContact.contactImageUrl];
-        [self.profileImageView sd_setImageWithURL:theUrl];
+        [self.profileImageView sd_setImageWithURL:theUrl placeholderImage:nil options:SDWebImageRefreshCached];
     }
     
     [self.callButton setEnabled:NO];

--- a/sample-with-framework/Applozic/Applozic/ViewControllers/ALUserProfileVC.m
+++ b/sample-with-framework/Applozic/Applozic/ViewControllers/ALUserProfileVC.m
@@ -114,7 +114,7 @@
     }
     else if(serverImageURL)
     {
-        [self.profileImage sd_setImageWithURL:serverImageURL];
+        [self.profileImage sd_setImageWithURL:serverImageURL placeholderImage:nil options:SDWebImageRefreshCached];
     }
     
     alContactService = [[ALContactService alloc] init];

--- a/sample-with-framework/Applozic/Applozic/Views/ALChatCell.m
+++ b/sample-with-framework/Applozic/Applozic/Views/ALChatCell.m
@@ -261,11 +261,11 @@
         if(alContact.contactImageUrl)
         {
             NSURL * theUrl1 = [NSURL URLWithString:alContact.contactImageUrl];
-            [self.mUserProfileImageView sd_setImageWithURL:theUrl1];
+            [self.mUserProfileImageView sd_setImageWithURL:theUrl1 placeholderImage:nil options:SDWebImageRefreshCached];
         }
         else
         {
-            [self.mUserProfileImageView sd_setImageWithURL:[NSURL URLWithString:@""]];
+            [self.mUserProfileImageView sd_setImageWithURL:[NSURL URLWithString:@""] placeholderImage:nil options:SDWebImageRefreshCached];
             [self.mNameLabel setHidden:NO];
             self.mUserProfileImageView.backgroundColor = [ALColorUtility getColorForAlphabet:receiverName];
         }

--- a/sample-with-framework/Applozic/Applozic/Views/ALImageCell.m
+++ b/sample-with-framework/Applozic/Applozic/Views/ALImageCell.m
@@ -250,11 +250,11 @@ UIViewController * modalCon;
         if(alContact.contactImageUrl)
         {
             NSURL * theUrl1 = [NSURL URLWithString:alContact.contactImageUrl];
-            [self.mUserProfileImageView sd_setImageWithURL:theUrl1];
+            [self.mUserProfileImageView sd_setImageWithURL:theUrl1 placeholderImage:nil options:SDWebImageRefreshCached];
         }
         else
         {
-            [self.mUserProfileImageView sd_setImageWithURL:[NSURL URLWithString:@""]];
+            [self.mUserProfileImageView sd_setImageWithURL:[NSURL URLWithString:@""] placeholderImage:nil options:SDWebImageRefreshCached];
             [self.mNameLabel setHidden:NO];
             self.mUserProfileImageView.backgroundColor = [ALColorUtility getColorForAlphabet:receiverName];
         }


### PR DESCRIPTION
Issue: #397 

Updated the Profile Images / Group Images **sd_setImageWithURL** method to include the cache option **SDWebImageRefreshCached**. 

This allows for the images to be cached and load as it exists, but with the option of checking the resources http header response to check if the resource has changed. So if a users profile image was replaced, but the url stays the same, the updated image will be pulled down and replace the old image in the cache. 