### PR TITLE
[AL-2389] Fix broadcast button user interaction

### DIFF
--- a/sample-with-framework/Applozic/Applozic/ViewControllers/ALMessagesViewController.m
+++ b/sample-with-framework/Applozic/Applozic/ViewControllers/ALMessagesViewController.m
@@ -643,7 +643,7 @@
             [newBroadCast setTitle:NSLocalizedStringWithDefaultValue(@"broadcastGroupOptionTitle", nil, [NSBundle mainBundle], @"New Broadcast", @"")
                           forState:UIControlStateNormal];
             
-            newBroadCast.userInteractionEnabled = ![ALApplozicSettings isBroadcastGroupEnable];
+            newBroadCast.userInteractionEnabled = [ALApplozicSettings isBroadcastGroupEnable];
             [newBroadCast setHidden:![ALApplozicSettings isBroadcastGroupEnable]];
             
         }break;


### PR DESCRIPTION
Bind the broadcast button's userInteractionEnabled property to isBroadcastGroupEnable